### PR TITLE
sony: Add the `tv` command with subcommands

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -1,8 +1,19 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
 )
+
+// ErrUsage is a sentinel error for when commands detect an for invalid
+// combinations of flags or args. Usually kong handles all this, but sometimes
+// you cannot express an invalid combination of args/flags in the kong tags.
+// It will typically be wrapped so should be checked with `errors.Is()`.
+var ErrUsage = errors.New("usage error")
 
 // braviaAPI is a kong CLI struct to be embedded in command structs that
 // talk to a Sony Bravia TV set. It contains the parameters to communicate
@@ -15,6 +26,7 @@ type braviaAPI struct {
 // SonyCmd is the kong CLI struct for the `sony` command.
 type SonyCmd struct {
 	Power SonyCmdPower `cmd:""`
+	Input SonyCmdInput `cmd:""`
 
 	braviaAPI
 }
@@ -22,6 +34,12 @@ type SonyCmd struct {
 // SonyCmdPower is the kong CLI struct for the `sony power` command.
 type SonyCmdPower struct {
 	State string `arg:"" optional:"" default:"" enum:",on,off" help:"Get/set power state"`
+}
+
+// SonyCmdInput is the kong CLI struct for the `sony input` command.
+type SonyCmdInput struct {
+	List  bool
+	Label string `arg:"" optional:"" default:"" help:"Get/set input"`
 }
 
 // Run (sony power) gets or sets the power state of a Sony Bravia TV. If no
@@ -43,4 +61,68 @@ func (sc *SonyCmdPower) Run(cli *CLI) error {
 		status = true
 	}
 	return c.SetPowerStatus(status)
+}
+
+// Run (sony input) gets or sets the currently displayed input of a Sony Bravia
+// TV set. If no argument is provided and the flag --list is not specified, the
+// currently selected input is printed with the label of the input as
+// configured on the TV, or with an input URI if no label is set. If --list is
+// specified, all the available input URIs with their labels (if any) are
+// listed. If an argument is provided and matches the label of one of the
+// inputs, the TV is set to that input. Otherwise the argument is assumed to be
+// a URI and sets the input to that URI.
+func (sc *SonyCmdInput) Run(cli *CLI) error {
+	if sc.Label != "" && sc.List {
+		return fmt.Errorf("%w: cannot use --list with a label", ErrUsage)
+	}
+
+	c := NewRESTClient(cli.TV.Hostname, cli.TV.PSK)
+	labels, err := c.Inputs()
+	if err != nil {
+		return fmt.Errorf("getting labels: %w", err)
+	}
+
+	switch {
+	// List all inputs
+	case sc.Label == "" && sc.List:
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "URI\tLABEL")
+
+		// Get the URIs from the map and sort them
+		uris := make([]string, 0, len(labels))
+		for k := range labels {
+			if strings.HasPrefix(k, "extInput:") {
+				uris = append(uris, k)
+			}
+		}
+		sort.Strings(uris)
+
+		for _, uri := range uris {
+			fmt.Fprintf(tw, "%s\t%s\n", uri, labels[uri])
+		}
+		tw.Flush() //nolint:errcheck,gosec
+
+	// Show selected input
+	case sc.Label == "" && !sc.List:
+		uri, err := c.SelectedInput()
+		if err != nil {
+			return fmt.Errorf("selected input: %w", err)
+		}
+		label := labels[uri]
+		if label == "" {
+			label = "unlabelled: " + uri
+		}
+		fmt.Println(label)
+
+	// Select input by label
+	case sc.Label != "":
+		uri := labels[sc.Label]
+		if uri == "" {
+			uri = sc.Label
+		}
+		if err := c.SetInput(uri); err != nil {
+			return fmt.Errorf("set input: %w", err)
+		}
+	}
+	return nil
 }

--- a/cmds.go
+++ b/cmds.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+)
+
+// braviaAPI is a kong CLI struct to be embedded in command structs that
+// talk to a Sony Bravia TV set. It contains the parameters to communicate
+// with a TV using the Bravia REST IP control protocol.
+type braviaAPI struct {
+	Hostname string `env:"OFFSCREEN_HOSTNAME" help:"Hostname of Sony Bravia TV"`
+	PSK      string `env:"OFFSCREEN_PSK" help:"Pre-shared key"`
+}
+
+// SonyCmd is the kong CLI struct for the `sony` command.
+type SonyCmd struct {
+	Power SonyCmdPower `cmd:""`
+
+	braviaAPI
+}
+
+// SonyCmdPower is the kong CLI struct for the `sony power` command.
+type SonyCmdPower struct {
+	State string `arg:"" optional:"" default:"" enum:",on,off" help:"Get/set power state"`
+}
+
+// Run (sony power) gets or sets the power state of a Sony Bravia TV. If no
+// argument is provided, the current power state is printed. If the argument is
+// present and is "on", the TV is turned on. If it is "off" the TV is turned
+// off.
+func (sc *SonyCmdPower) Run(cli *CLI) error {
+	c := NewRESTClient(cli.TV.Hostname, cli.TV.PSK)
+	if sc.State == "" {
+		state, err := c.PowerStatus()
+		if err != nil {
+			return fmt.Errorf("power status: %w", err)
+		}
+		fmt.Println(state)
+		return nil
+	}
+	status := false
+	if sc.State == "on" {
+		status = true
+	}
+	return c.SetPowerStatus(status)
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ offscreen turns off/on your Sony Bravia when the screen saver turns on/off
 
 type CLI struct {
 	Version kong.VersionFlag `short:"V" help:"Print program version"`
+
+	TV SonyCmd `cmd:"" help:"query/control TV set"`
 }
 
 func main() {

--- a/sony.go
+++ b/sony.go
@@ -151,6 +151,28 @@ func NewRESTClient(hostname, psk string) *RESTClient {
 // e.g. `_, err := post[empty](...)`.
 type empty struct{}
 
+// PowerStatus returns the power status of the TV - i.e. whether it is on
+// or off. On is returned as "active", off as "standby". If an error occurred
+// communicating with the TV, an error is returned with an empty string status.
+func (c *RESTClient) PowerStatus() (string, error) {
+	type powerStatusResponse struct {
+		Status string `json:"status"`
+	}
+	resp, err := post[powerStatusResponse](c, "system", "getPowerStatus", "1.0", nil)
+	if err != nil {
+		return "", err
+	}
+	return resp.Status, nil
+}
+
+// SetPowerStatus sets the TV power status to on (status == true) or off
+// (status == false).
+func (c *RESTClient) SetPowerStatus(status bool) error {
+	param := map[string]bool{"status": status}
+	_, err := post[empty](c, "system", "setPowerStatus", "1.0", param)
+	return err
+}
+
 // post[T] executes a REST IP control command returning the result of type T or
 // an error if the command did not succeed. If no data was returned from the
 // HTTP call, the returned value will be nil. The `empty` type can be used when

--- a/sony.go
+++ b/sony.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// RESTClient talks to a Sony Bravia TV using the [REST IP control protocol].
+//
+// The full API is not implemented, only just enough to power the set on and
+// off based on a condition of an input being selected, and to switch inputs.
+// This allows the display to be turned off if X11 XSS says the screen has been
+// blanked, and that can be filtered to only turn if off if a particular input
+// is selected. The screen should not be turned off if it is not displaying the
+// screen that was just blanked. When XSS says a screen has been unblanked, if
+// the screen is off, turn it on and select a particular input.
+//
+// [REST IP control protocol]: https://pro-bravia.sony.net/develop/integrate/rest-api/spec/index.html
+type RESTClient struct {
+	// BaseURL is the URL to address the TV set to be controlled. It will
+	// typically be a hostname and the `/sony` path.
+	BaseURL string
+
+	// PSK is the Pre-Shared Key configured on the TV set. It is
+	// essentially a password on the service (that is sent in plain-text on
+	// the network).
+	PSK string
+
+	HTTPClient *http.Client
+}
+
+var (
+	// ErrHTTPStatus is a sentinel error for all HTTP status-based errors, It is
+	// intended to be used with `errors.Is(err, ErrHTTPStatus)`.
+	ErrHTTPStatus = errors.New("http")
+
+	// ErrSony is a sentinel error for errors returned by the REST IP
+	// control protocol in the body of a response.
+	ErrSony = errors.New("sony")
+)
+
+// HTTPStatusError captures the status code of a HTTP response that is to be
+// treated as an error. It is not necessarily just a 4xx or 5xx error - it
+// could be any status code that is unhandled.
+type HTTPStatusError int
+
+// Error formats a HTTP status code as its text description as per
+// http.StatusText().
+func (err HTTPStatusError) Error() string {
+	return http.StatusText(int(err))
+}
+
+// Unwrap returns ErrHTTP for all errors so HTTPStatusErrors can be checked
+// with `errors.Is(err, ErrHTTP)`, instead of the two-line
+// `var errHTTP HTTPStatusErr; errorsAs(err, &errHTTP)`. The latter is still
+// possible if the error type is required.
+func (err HTTPStatusError) Unwrap() error {
+	return ErrHTTPStatus
+}
+
+// SonyError captures an error returned by the Sony REST IP control protocol
+// as an error returned in the payload of an HTTP response. These errors are
+// returned as an error code and a string describing it.
+type SonyError struct {
+	Code    int
+	Message string
+}
+
+// NewSonyError returns a SonyError from the response. The []any parameter
+// is expected to have two elements, a float64 (code) and a string (message).
+// If the size or types are not as just described, a InvalidResponseError
+// is returned instead with the body that could not be parsed.
+//
+//nolint:goerr113 // we _are_ using wrapped errors
+func NewSonyError(resp []any, body []byte) error {
+	if len(resp) != 2 {
+		return InvalidResponseError{
+			wrapped: errors.New("wrong number of error parameters"),
+			Body:    body,
+		}
+	}
+	code, ok := resp[0].(float64) // float64 as JSON decodes numbers as float64
+	if !ok {
+		return InvalidResponseError{
+			wrapped: errors.New("first parameter is not a number"),
+			Body:    body,
+		}
+	}
+	msg, ok := resp[1].(string)
+	if !ok {
+		return InvalidResponseError{
+			wrapped: errors.New("second parameter is not a string"),
+			Body:    body,
+		}
+	}
+	return SonyError{Code: int(code), Message: msg}
+}
+
+// Error returns the message portion of the error.
+func (err SonyError) Error() string {
+	return err.Message
+}
+
+// Unwrap returns ErrSony for all errors so SonyErrors can easily be checked
+// with `errors.Is(err, ErrSony)` for when you don't care about the specific
+// code or message of the error (when you would use `errors.As()`).
+func (err SonyError) Unwrap() error {
+	return ErrSony
+}
+
+// InvalidResponseError captures a response from the TV that could not be parsed
+// as expected. It wraps an error describing the error condition and the body that
+// could not be parsed.
+type InvalidResponseError struct {
+	wrapped error
+	Body    []byte
+}
+
+// Error returns the error string of the wrapped error with the body appended.
+func (err InvalidResponseError) Error() string {
+	return fmt.Sprintf("%v\nBody: %s", err.wrapped, string(err.Body))
+}
+
+// Unwrap returns the error that err wraps.
+func (err InvalidResponseError) Unwrap() error {
+	return err.wrapped
+}
+
+// NewRESTClient creates and returns a BraviaClient reachable at the given
+// hostname, using the Pre-Shared Key given as psk as the password. If psk is
+// the empty string, it is not used.
+func NewRESTClient(hostname, psk string) *RESTClient {
+	return &RESTClient{
+		BaseURL: "http://" + hostname + "/sony",
+		PSK:     psk,
+		HTTPClient: &http.Client{
+			// Timeout after 10s. Arguably that's too long.
+			// This doesn't really need to be configurable.
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// empty is a type to be used with `post[T]()` for when a response is not returned.
+// e.g. `_, err := post[empty](...)`.
+type empty struct{}
+
+// post[T] executes a REST IP control command returning the result of type T or
+// an error if the command did not succeed. If no data was returned from the
+// HTTP call, the returned value will be nil. The `empty` type can be used when
+// no response is expected:
+//
+//	_, err := post[empty](client, service, method, version, params)
+//
+// The protocol docs define service, method and version. Params is any value
+// that can be marshaled as JSON and will be passed in the `params` part of the
+// JSON payload of the HTTP request. Note that the method argument is not an
+// HTTP method, but a method as defined in the protocol docs.
+//
+// The `result` field in the JSON response will be unmarshaled into a variable
+// of type T and returned.
+func post[T any](c *RESTClient, service, method, version string, params any) (*T, error) {
+	brq, err := c.newRequest(service, method, version, params)
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	resp, err := c.do(brq)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	bresp, err := decodeResp[T](resp)
+	if err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if len(bresp) == 0 {
+		return nil, nil //nolint:nilnil // T can be `empty` for no result expected. not an error.
+	}
+	return &bresp[0], nil
+}
+
+func (c *RESTClient) newRequest(service, method, version string, params any) (*http.Request, error) {
+	payload := struct {
+		Method  string `json:"method"`
+		Version string `json:"version"`
+		ID      int    `json:"id"`
+		Params  []any  `json:"params"`
+	}{
+		Method:  method,
+		Version: version,
+		Params:  makeParams(params),
+		ID:      1, // ID 0 is invalid, but we don't care about this
+	}
+	u, err := url.JoinPath(c.BaseURL, service)
+	if err != nil {
+		return nil, fmt.Errorf("join path: %w", err)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(body)) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	if c.PSK != "" {
+		req.Header.Add("X-Auth-PSK", c.PSK)
+	}
+	return req, nil
+}
+
+func (c *RESTClient) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close() //nolint:errcheck,gosec // When does this close ever fail meaningfully?
+		return nil, HTTPStatusError(resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func decodeResp[T any](resp *http.Response) ([]T, error) {
+	defer resp.Body.Close() //nolint:errcheck // When does this close ever fail meaningfully?
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("readall: %w", err)
+	}
+
+	bresp := struct {
+		Result []T   `json:"result"`
+		Error  []any `json:"error"`
+	}{}
+
+	if err := json.Unmarshal(body, &bresp); err != nil {
+		return nil, InvalidResponseError{
+			wrapped: err,
+			Body:    body,
+		}
+	}
+	// Errors are returned like: `{"error": [40005, "Display Is Turned Off"]}`
+	if bresp.Error != nil {
+		return nil, NewSonyError(bresp.Error, body)
+	}
+	return bresp.Result, nil
+}
+
+func makeParams(v any) []any {
+	if v == nil {
+		return []any{}
+	}
+	return []any{v}
+}


### PR DESCRIPTION
Add the `tv` command with a `power`, `input` and `toggle` subcommand.
These allow you to query and control the power state and the currently
selected input making it possible to turn the TV off and on, and to
select different inputs given multiple computers are connected via those
different inputs.

A "REST" client is added to support this, implementing a minimal amount
of the Sony Bravia REST IP control protocol.

Link: https://pro-bravia.sony.net/develop/integrate/rest-api/spec/index.html