### PR TITLE
screen: Add commands to manage TV screen

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 issues:
-   exclude-use-default: false
-   exclude:
+  exclude-use-default: false
+  exclude:
     - "^don't use ALL_CAPS"
     - "^ST1003: should not use ALL_CAPS"
     - "^G304: Potential file inclusion via variable"
@@ -29,6 +29,7 @@ linters:
     - lll
     - maligned
     - nlreturn
+    - nonamedreturns
     - nosnakecase
     - paralleltest
     - revive

--- a/cmds.go
+++ b/cmds.go
@@ -1,3 +1,4 @@
+//nolint:goerr113 // dynamic errors in main are OK
 package main
 
 import (

--- a/cmds.go
+++ b/cmds.go
@@ -67,6 +67,7 @@ type SonyCmdInput struct {
 
 // SonyCmdToggle is the kong CLI struct for the `sony toggle` command.
 type SonyCmdToggle struct {
+	screenFlags
 	Input string `short:"i" help:"Specify host input, do not autodetect"`
 }
 
@@ -284,12 +285,8 @@ func (sc *SonyCmdToggle) Run(cli *CLI) error {
 			return fmt.Errorf("could not get selected input: %w", err)
 		}
 		if input == ourInput {
-			// TODO(camh): Make this just enable the screen saver
-			// when offscreen is complete and let it take care of
-			// turning off the TV with the standad logic. That way
-			// other screens attached to the host will also be blanked.
-			if err := c.SetPowerStatus(false); err != nil {
-				return fmt.Errorf("could not turn off screen: %w", err)
+			if err := sc.screen.Blank(); err != nil {
+				return fmt.Errorf("could not blank screen: %w", err)
 			}
 			return nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module foxygo.at/offscreen
 
 go 1.19
 
-require github.com/alecthomas/kong v0.7.0
+require (
+	github.com/alecthomas/kong v0.7.0
+	github.com/anoopengineer/edidparser v0.0.0-20140306172611-ad417053131c
+	github.com/jezek/xgb v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -2,4 +2,8 @@ github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2o
 github.com/alecthomas/kong v0.7.0 h1:YIjJUiR7AcmHxL87UlbPn0gyIGwl4+nYND0OQ4ojP7k=
 github.com/alecthomas/kong v0.7.0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
+github.com/anoopengineer/edidparser v0.0.0-20140306172611-ad417053131c h1:wo4JgGRW+6/KSS5CqHIpc3xdDnyGqKNWSH7TIsP9XlI=
+github.com/anoopengineer/edidparser v0.0.0-20140306172611-ad417053131c/go.mod h1:fEt61NePh3ZMxA+g3iC4CaGzY9lEsHRUkYJY2x0lBAw=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/jezek/xgb v1.1.0 h1:wnpxJzP1+rkbGclEkmwpVFQWpuE2PUGNUzP8SbfFobk=
+github.com/jezek/xgb v1.1.0/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=

--- a/main.go
+++ b/main.go
@@ -17,8 +17,9 @@ offscreen turns off/on your Sony Bravia when the screen saver turns on/off
 type CLI struct {
 	Version kong.VersionFlag `short:"V" help:"Print program version"`
 
-	Run RunCmd  `cmd:"" default:"1" help:"Run offscreen"`
-	TV  SonyCmd `cmd:"" help:"query/control TV set"`
+	Run  RunCmd  `cmd:"" default:"1" help:"Run offscreen"`
+	List ListCmd `cmd:"" help:"List connected monitor IDs"`
+	TV   SonyCmd `cmd:"" help:"query/control TV set"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ offscreen turns off/on your Sony Bravia when the screen saver turns on/off
 type CLI struct {
 	Version kong.VersionFlag `short:"V" help:"Print program version"`
 
-	TV SonyCmd `cmd:"" help:"query/control TV set"`
+	Run RunCmd  `cmd:"" default:"1" help:"Run offscreen"`
+	TV  SonyCmd `cmd:"" help:"query/control TV set"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/alecthomas/kong"
@@ -27,7 +29,32 @@ func main() {
 	kctx := kong.Parse(&cli,
 		kong.Description(description),
 		kong.Vars{"version": version},
+		kong.PostBuild(func(k *kong.Kong) error {
+			return kong.Visit(k.Model, setInputDefault)
+		}),
 	)
 	err := kctx.Run(&cli)
 	kctx.FatalIfErrorf(err)
+}
+
+// setInputDefault is a kong.Visitor that sets the default of any flag named
+// "input" to the (possibly modified) hostname as a label. If the hostname is
+// longer than 7 characters, it is truncated to 7 characters by taking the
+// first six characters and appending the last character (e.g. palantir ->
+// palantr). This is because the TV labels are limited to 7 characters and this
+// transformation gives a reasonable looking name. It is called by [kong.Visit]
+// in a [kong.PostBuild] function.
+func setInputDefault(node kong.Visitable, next kong.Next) error {
+	if f, ok := node.(*kong.Flag); ok && f.Name == "input" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("could not get hostname to set default input: %w", err)
+		}
+		if len(hostname) > 7 {
+			hostname = hostname[0:6] + hostname[len(hostname)-1:]
+		}
+		f.Default = hostname
+		f.HasDefault = true
+	}
+	return next(nil)
 }

--- a/screen.go
+++ b/screen.go
@@ -1,0 +1,244 @@
+//nolint:goerr113 // Dynamic errors in main are OK
+package main
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/anoopengineer/edidparser/edid"
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/randr"
+	"github.com/jezek/xgb/screensaver"
+	"github.com/jezek/xgb/xproto"
+)
+
+// Screen is a connection to an X Windows server for the purposes of watching
+// for screen saver events and for the presence of a particular monitor. The
+// monitor is identified by a manufacturer ID and a product code, both fields
+// from the monitor's [EDID] block. Screen saver events are only monitored
+// while a monitor matching that manufacturer ID / product code pair is plugged
+// into the X server.
+//
+// [EDID]: https://en.wikipedia.org/wiki/Extended_Display_Identification_Data
+type Screen struct {
+	xconn   *xgb.Conn
+	rootWin xproto.Window
+
+	manufacturerID string
+	productCode    uint16
+
+	ssOn    atomic.Bool
+	present atomic.Bool
+}
+
+// ScreenWatcher is a callback interface that is called by [Watch] when the
+// state of the screen saver changes - i.e. when the screen saver turns on or
+// off. It is not called if the TV/monitor is not plugged in.
+type ScreenWatcher interface {
+	SSChange(ssOn bool)
+}
+
+// ScreenWatcherFunc is a function adaptor for the ScreenWatcher interface.
+type ScreenWatcherFunc func(ssOn bool)
+
+// SSChange calls the function adaptor with the value of ssOn.
+func (swf ScreenWatcherFunc) SSChange(ssOn bool) {
+	swf(ssOn)
+}
+
+// NewScreen returns a new Screen with a connection to the X server for the
+// given display, with the RANDR and SCREENSAVER extensions initialised (i.e.
+// verified that the X server has these extensions). The manufacturerID and
+// productCode are used for monitor presence detection.
+//
+// An error is returned if the connection to the X server could not be
+// established, the extensions are not present on the server or the current
+// screen saver state or monitor presence could not be queried.
+func NewScreen(display, manufacturerID string, productCode uint16) (*Screen, error) {
+	c, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		return nil, fmt.Errorf("could not open display %s: %w", display, err)
+	}
+
+	// Intitialise the RANDR and SCREENSAVER extensions. These will fail if the
+	// X11 server does not support these extensions.
+	if err := randr.Init(c); err != nil {
+		return nil, fmt.Errorf("could not initialise RANDR extension: %w", err)
+	}
+	if err := screensaver.Init(c); err != nil {
+		return nil, fmt.Errorf("could not initialise SCREENSAVER extension: %w", err)
+	}
+
+	s := &Screen{
+		xconn:          c,
+		rootWin:        xproto.Setup(c).DefaultScreen(c).Root,
+		manufacturerID: manufacturerID,
+		productCode:    productCode,
+	}
+
+	// Set the initial state of the screen saver and monitor presence.
+	ssOn, err := s.queryScreenSaver()
+	if err != nil {
+		return nil, fmt.Errorf("could not query screen saver state: %w", err)
+	}
+	s.ssOn.Store(ssOn)
+
+	present, err := s.queryPresence()
+	if err != nil {
+		return nil, fmt.Errorf("could not query TV presence: %w", err)
+	}
+	s.present.Store(present)
+
+	return s, nil
+}
+
+// Close closes the screen's connection to the X server. This will cause
+// [Screen.Watch] to return.
+func (s *Screen) Close() {
+	s.xconn.Close()
+}
+
+// IsScreenSaverOn returns the current state of the screen saver.
+func (s *Screen) IsScreenSaverOn() bool {
+	return s.ssOn.Load()
+}
+
+// IsPresent returns whether the screen's monitor is present or not.
+func (s *Screen) IsPresent() bool {
+	return s.present.Load()
+}
+
+// Blank forces the screen saver to an active/enabled state.
+func (s *Screen) Blank() error {
+	return xproto.ForceScreenSaverChecked(s.xconn, xproto.ScreenSaverActive).Check()
+}
+
+// Watch loops while the connection to the X server is open (see
+// [Screen.Close]) calling the given watcher when the state of the screen saver
+// changes, but only if the screen's monitor is present. If the screen's
+// monitor becomes present the state of the screen saver at that time is passed
+// to the watcher.
+func (s *Screen) Watch(watcher ScreenWatcher) error {
+	// Listen for randr events (monitor plug/unplug)
+	err := randr.SelectInputChecked(s.xconn, s.rootWin, randr.NotifyMaskOutputChange).Check()
+	if err != nil {
+		return fmt.Errorf("could not watch RANDR events: %w", err)
+	}
+
+	// Listen for screensaver events (screensaver on/off)
+	// For some reason, screensaver wants the root window as a "Drawable"
+	drawableRoot := xproto.Drawable(s.rootWin)
+	err = screensaver.SelectInputChecked(s.xconn, drawableRoot, screensaver.EventNotifyMask).Check()
+	if err != nil {
+		return fmt.Errorf("could not watch SCREENSAVER events: %w", err)
+	}
+
+	for {
+		ev, err := s.xconn.WaitForEvent()
+		if err != nil {
+			return fmt.Errorf("could not wait for events: %w", err)
+		}
+		if ev == nil { // X11 connection closed
+			return nil
+		}
+		switch event := ev.(type) {
+		case screensaver.NotifyEvent:
+			isOn := event.State == screensaver.StateOn || event.State == screensaver.StateCycle
+			wasOn := s.ssOn.Swap(isOn)
+			// Send the screensaver state if it changes and the monitor is present
+			if isOn != wasOn && s.IsPresent() {
+				watcher.SSChange(isOn)
+			}
+		case randr.NotifyEvent:
+			// It is too hard to determine from the randr event whether it is for
+			// the display being connected/disconnected, so for every randr event,
+			// just check the presence by checking the randr properties.
+			present, err := s.queryPresence()
+			if err != nil {
+				return fmt.Errorf("could not query TV presence: %w", err)
+			}
+			wasPresent := s.present.Swap(present)
+			// If the monitor has just appeared, send the screensaver state
+			if present && !wasPresent {
+				watcher.SSChange(s.IsScreenSaverOn())
+			}
+		}
+	}
+}
+
+// queryScreenSaver queries the X server for the state of the screen saver.
+func (s *Screen) queryScreenSaver() (bool, error) {
+	info, err := screensaver.QueryInfo(s.xconn, xproto.Drawable(s.rootWin)).Reply()
+	if err != nil {
+		return false, fmt.Errorf("QueryInfo failed: %w", err)
+	}
+	return info.State == screensaver.StateOn, nil
+}
+
+// queryPresence queries the X server for the presence of the screen's monitor.
+func (s *Screen) queryPresence() (bool, error) {
+	var present bool
+	err := RangeEDID(s.xconn, s.rootWin, func(_ randr.Output, e *edid.Edid) (bool, error) {
+		if e.ManufacturerId == s.manufacturerID && e.ProductCode == s.productCode {
+			present = true
+			return false /* stop ranging */, nil
+		}
+		return true /* keep ranging */, nil
+	})
+	return present, err
+}
+
+// RangeEDIDFunc is called by [RangeEDID] for each X11 xrandr output that has
+// EDID data. The function returns a bool that tells [RangeEDID] whether to
+// continue ranging over subsequent outputs or not, and an error that if not
+// nil will be returned to the caller of [RangeEDID]. If the RangeEDIDFunc
+// returns false or an error, [RangeEDID] terminates and returns to the caller.
+type RangeEDIDFunc func(output randr.Output, edidData *edid.Edid) (cont bool, err error)
+
+// RangeEDID calls fn for each X11 xrandr output that has an EDID property.
+// If fn returns false or an error, iteration will terminate. The error is
+// returned.
+//
+// If root is zero (not a valid window ID) then RangeEDID will get it from
+// the provided xgb.Conn. This needs to unpack a bunch of serialised data,
+// so it can be more efficient to provide the root window ID if you have it.
+func RangeEDID(c *xgb.Conn, root xproto.Window, fn RangeEDIDFunc) error {
+	if root == xproto.Window(0) {
+		root = xproto.Setup(c).DefaultScreen(c).Root
+	}
+
+	r, err := randr.GetScreenResourcesCurrent(c, root).Reply()
+	if err != nil {
+		return fmt.Errorf("could not get screens: %w", err)
+	}
+
+	edidAtom, err := xproto.InternAtom(c, false /* OnlyIfExists */, 4, "EDID").Reply()
+	if err != nil {
+		return fmt.Errorf("could not intern X11 atom: %w", err)
+	}
+
+	for _, output := range r.Outputs {
+		// the length of 64 gives a maximum EDID data size of 256 bytes (4 * 64).
+		// EDID maxes out at 256 bytes long, so should be fine.
+		const offset, length, del, pending = 0, 64, false, false
+		// https://cgit.freedesktop.org/xorg/proto/randrproto/tree/randrproto.txt#n872
+		opr, err := randr.GetOutputProperty(c, output, edidAtom.Atom, xproto.AtomAny, offset, length, del, pending).Reply()
+		if err != nil {
+			return fmt.Errorf("could not get output properties: %w", err)
+		}
+		if opr.BytesAfter != 0 {
+			return fmt.Errorf("EDID data too large. Max is 256 bytes, got %d bytes", 256+opr.BytesAfter)
+		}
+		if len(opr.Data) == 0 {
+			continue
+		}
+		ed, err := edid.NewEdid(opr.Data)
+		if err != nil {
+			return fmt.Errorf("could not parse EDID data: %w", err)
+		}
+		if cont, err := fn(output, ed); !cont || err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sony.go
+++ b/sony.go
@@ -1,3 +1,4 @@
+//nolint:goerr113 // dynamic errors in main are OK
 package main
 
 import (
@@ -76,8 +77,6 @@ type SonyError struct {
 // is expected to have two elements, a float64 (code) and a string (message).
 // If the size or types are not as just described, a InvalidResponseError
 // is returned instead with the body that could not be parsed.
-//
-//nolint:goerr113 // we _are_ using wrapped errors
 func NewSonyError(resp []any, body []byte) error {
 	if len(resp) != 2 {
 		return InvalidResponseError{


### PR DESCRIPTION
Add the `run` and `list` commands to manage a TV screen connected to the
X Windows server.

When `offscreen` is run with the `run` command (the default command, so
the `run` verb is not necessary), it will watch the X server for changes
to the screen saver state and propagate that state to the connected Sony
TV with a set of rules such that it works for multiple machines
connected to the TV on different inputs, each running `offscreen`.

The `list` command lists the manufacturer ID and product code of all
screens connected to the X server so that users can discover these
values for running offscreen against their Sony TVs if they have a
different model to the supported default.