### PR TITLE
config: Allow build-time config of bravia config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ clean:: ## Remove generated files
 .PHONY: all check-uptodate ci clean
 
 # --- Build --------------------------------------------------------------------
-GO_LDFLAGS = -X main.version=$(VERSION)
+GO_LDFLAGS = -X main.version=$(VERSION) \
+	     -X main.buildtimeHost=$(OFFSCREEN_HOSTNAME) \
+	     -X main.buildtimePSK=$(OFFSCREEN_PSK)
 CMDS = .
 
 ## Build offscreen binary

--- a/README.md
+++ b/README.md
@@ -20,3 +20,30 @@ is actually connected to the computer so that we do not try to turn it on and
 off if it is not actually plugged into the machine. This is handy for laptops
 which may get unplugged but remain on wifi, so are still able to control the TV
 when we may not want it to.
+
+## Building
+
+You can build offscreen with:
+
+    make build
+
+and the binary will be written to `out/offscreen` in the root of the repository.
+
+⚠️  Caution ⚠️
+
+If the environment variables `OFFSCREEN_HOSTNAME` or `OFFSCREEN_PSK` are set in
+the environment when you build the binary with `make build` or `make install`,
+the values from those environment variables will be built into the binary as the
+default for the `--hostname` and `--psk` flags. The pre-shared key (PSK) is
+sensitive so be aware if you are going to distribute the binary.
+
+This is done to make it easier to use the binary across multiple machines
+without requiring the PSK or hostname environment variables set up in your shell
+rc file, or requiring the argument be supplied when running. But this could leak
+your PSK if you share such a binary.
+
+If you take the binary from the [offscreen GitHub releases page] or build it
+with `go install foxygo.at/offscreen@latest`, there will be no default hostname
+or PSK embedded in the binary.
+
+[offscreen GitHub releases page]: https://github.com/foxygoat/offscreen/releases

--- a/cmds_test.go
+++ b/cmds_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/matryer/is"
+)
+
+var buildtimeVarTests = []struct {
+	name string
+
+	buildHost, buildPSK string
+	envHost, envPSK     string
+	cliHost, cliPSK     string
+
+	wantHost, wantPSK string
+}{
+	{"none", "", "", "", "", "", "", "", ""},
+	{"build only", "example.com", "1234", "", "", "", "", "example.com", "1234"},
+	{"env only", "", "", "example.com", "1234", "", "", "example.com", "1234"},
+	{"cli only", "", "", "", "", "example.com", "1234", "example.com", "1234"},
+	{"build+env", "example.com", "1234", "example2.com", "9876", "", "", "example2.com", "9876"},
+	{"build+cli", "example.com", "1234", "", "", "example2.com", "9876", "example2.com", "9876"},
+}
+
+func TestBuildtimeVars(t *testing.T) {
+	for _, tt := range buildtimeVarTests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+
+			var cli CLI
+			parser, err := kong.New(&cli)
+			is.NoErr(err) // failed to create kong parser
+
+			buildtimeHost = tt.buildHost
+			buildtimePSK = tt.buildPSK
+			t.Setenv("OFFSCREEN_HOSTNAME", tt.envHost)
+			t.Setenv("OFFSCREEN_PSK", tt.envPSK)
+			args := []string{"tv", "power"}
+			if tt.cliHost != "" {
+				args = append(args, "--hostname", tt.cliHost)
+			}
+			if tt.cliPSK != "" {
+				args = append(args, "--psk", tt.cliPSK)
+			}
+
+			_, err = parser.Parse(args)
+			is.NoErr(err)                          // failed to parse command line
+			is.Equal(tt.wantHost, cli.TV.Hostname) // hostname incorrect
+			is.Equal(tt.wantPSK, cli.TV.PSK)       // PSK incorrect
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/anoopengineer/edidparser v0.0.0-20140306172611-ad417053131c
 	github.com/jezek/xgb v1.1.0
 )
+
+require github.com/matryer/is v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,5 @@ github.com/anoopengineer/edidparser v0.0.0-20140306172611-ad417053131c/go.mod h1
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/jezek/xgb v1.1.0 h1:wnpxJzP1+rkbGclEkmwpVFQWpuE2PUGNUzP8SbfFobk=
 github.com/jezek/xgb v1.1.0/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=


### PR DESCRIPTION
Pass the `$OFFSCREEN_HOSTNAME` and `$OFFSCREEN_PSK` env vars to the
build so they can be built into the binary. This makes the generated
binaries self-contained for a particular deployment meaning these vars
do not need to be set at run time.

I manage these vars in a `.envrc` file (for `direnv`) and do not have
them in my `.bashrc`. This change builds the values into the binary when
built locally (not on CI though so not in any released binaries). I can
then copy this binary to all machines connected to the Bravia TV so it
is preconfigured to talk to it.

The build-time vars are only used if the values are not specified at
run-time - either via env vars or the CLI directly.

Add some tests for this as I got the code wrong the first time. This
introduces `github.com/matryer/is` as a testing dependency.