### PR TITLE
ci: Fix goreleaser config after upgrade

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,10 +3,6 @@ builds:
       - linux
 archives:
   - format: binary
-    replacements:
-      linux: Linux
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ lint:
 release: nexttag
 	git tag $(RELEASE_TAG)
 	git push origin $(RELEASE_TAG)
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 nexttag:
 	$(if $(RELEASE_TAG),,$(eval RELEASE_TAG := $(shell $(NEXTTAG_CMD))))


### PR DESCRIPTION
Fix the goreleaser config after commit c4468b9e upgraded it from 1.12.3
to 1.22.1. Version 1.19.0 removed the deprecated `archives.replacements`
field, which could be replaced with `name_template`. However, I have no
good reason for the replacements - that part of the config was just
cargo-culted I think - so just get rid of the field altogether. This
will change the naming of the release artifacts on GitHub.

Also use `--clean` instead of `--rm-dist` in the `Makefile` as the
latter is deprecated and will likely break in a future upgrade.